### PR TITLE
Remove transparent nav logic

### DIFF
--- a/src/components/MobileNav.astro
+++ b/src/components/MobileNav.astro
@@ -1,5 +1,5 @@
 ---
-import { parseHref } from "../lib/helpers.js";
+import { parseHref } from '../lib/helpers.js';
 
 const { menuLinks } = Astro.props;
 const pathname = new URL(Astro.request.url).pathname;
@@ -7,39 +7,38 @@ const currentPath = pathname.slice(1); // remove the first "/"
 ---
 
 <script>
-  const navHamburger = document.querySelector(".nav__hamburger");
-  const navMobile = document.querySelector(".nav__mobile");
-  const closeMenu = document.querySelector(".nav__mobile .close-button");
+  const navHamburger = document.querySelector('.nav__hamburger');
+  const navMobile = document.querySelector('.nav__mobile');
+  const closeMenu = document.querySelector('.nav__mobile .close-button');
 
-  navHamburger?.addEventListener("click", () => {
-    navMobile?.classList.toggle("nav__mobile--open");
+  navHamburger?.addEventListener('click', () => {
+    navMobile?.classList.toggle('nav__mobile--open');
   });
 
-  document.addEventListener("click", (event) => {
+  document.addEventListener('click', (event) => {
     const tar = event.target as HTMLElement;
-    if (!tar.closest(".nav__mobile") && !tar.closest(".nav__hamburger")) {
-      navMobile?.classList.remove("nav__mobile--open");
+    if (!tar.closest('.nav__mobile') && !tar.closest('.nav__hamburger')) {
+      navMobile?.classList.remove('nav__mobile--open');
     }
   });
 
-  closeMenu?.addEventListener("click", () => {
-    navMobile?.classList.remove("nav__mobile--open");
+  closeMenu?.addEventListener('click', () => {
+    navMobile?.classList.remove('nav__mobile--open');
   });
 </script>
 
-<div class="nav__mobile" tabindex="1">
-  <button class="close-button" aria-label="close">
-    <svg class="icon icon--16">
-      <use href="/icon/instagram.svg#close"></use>
+<div class='nav__mobile' tabindex='1'>
+  <button class='close-button' aria-label='close'>
+    <svg class='icon icon--16'>
+      <use href='/icon/instagram.svg#close'></use>
     </svg>
   </button>
   <section>
     {
-      menuLinks.map((link) => (
+      menuLinks.map((link: any) => (
         <a
-          class={currentPath === parseHref(link) ? "active" : ""}
-          href={link.href}
-        >
+          class={currentPath === parseHref(link) ? 'active' : ''}
+          href={link.href}>
           {link.name}
         </a>
       ))

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -4,9 +4,13 @@ import { parseHref } from '../lib/helpers.js';
 
 const pathname = new URL(Astro.request.url).pathname;
 const currentPath = pathname.slice(1); // remove the first "/"
-const isSolidBackground = ['about/', 'tabs/', 'gear/'].includes(currentPath);
 
-const menuLinks = [
+interface MenuLink {
+  name: string;
+  href: string;
+}
+
+const menuLinks: MenuLink[] = [
   { name: 'Home', href: '/' },
   { name: 'About', href: '/about/' },
   { name: 'Albums', href: '/albums/' },
@@ -16,31 +20,7 @@ const menuLinks = [
 ];
 ---
 
-<script>
-  const header = document.querySelector('.site-nav');
-  const options = {
-    // rootMargin: '900px 0px 90px 0px',
-    rootMargin: '0px 0px -100% 0px',
-    threshold: 0,
-  };
-
-  const callback = (entries, observer) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting && header) {
-        header.classList.add('site-nav--scrolled');
-      } else if (!entry.isIntersecting && header) {
-        header.classList.remove('site-nav--scrolled');
-      }
-    });
-  };
-
-  const observer = new IntersectionObserver(callback, options);
-
-  const targetEl = document.querySelector('[data-header]');
-  observer.observe(targetEl);
-</script>
-
-<header class:list={['site-nav', { 'site-nav--solid': isSolidBackground }]}>
+<header class='site-nav'>
   <nav class='site-content-width nav'>
     <a href='/' class='nav-home-link'>Anton Emery - Celtic Guitar</a>
     <div class='nav__main'>

--- a/src/styles/_nav.scss
+++ b/src/styles/_nav.scss
@@ -1,6 +1,7 @@
 .site-nav {
-  background: transparent;
-  position: fixed;
+  background: white;
+  position: sticky;
+  top: 0;
   width: 100%;
   transition: background 0.5s ease-in-out;
   z-index: 3;
@@ -20,17 +21,6 @@
     font-family: 'Lusitana', serif;
     font-size: var(--font-size-md);
     font-weight: bold;
-  }
-
-  &--solid {
-    background: white;
-  }
-
-
-  &--scrolled {
-    background: white;
-    transition: background 0.5s ease-in-out;
-    z-index: 3;
   }
 }
 


### PR DESCRIPTION
Remove the logic that transitions the top nav menu from transparent to a solid white background on scroll. This is to difficult to manage along with a different background image for each page.

Give the nav menu a solid white background and have it fixed to the top of the viewport when scrolling.